### PR TITLE
[codex] repair Office parsing and context accounting / 修复 Office 解析与上下文统计

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/context/RollingContext.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/context/RollingContext.kt
@@ -3,6 +3,7 @@ package me.rerere.rikkahub.data.ai.context
 import kotlinx.serialization.Serializable
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.ui.UIMessage
+import me.rerere.ai.ui.UIMessagePart
 import kotlin.uuid.Uuid
 
 /** A persisted summary of a stable prefix of the active conversation branch. */
@@ -52,8 +53,7 @@ fun createRollingContextPlan(
     val coveredCount = storedSummary?.coveredMessageCount(messages) ?: 0
     val previousSummary = storedSummary?.takeIf { coveredCount > 0 }
     val unsummarizedMessages = messages.drop(coveredCount)
-    val workingTokens = estimateContextTokens(unsummarizedMessages) +
-        previousSummary.orEmptySummaryTokens()
+    val workingTokens = estimateActiveContextTokens(messages, previousSummary)
     if (!force && workingTokens < effectiveThreshold) return null
 
     val keepCount = unsummarizedMessages.recentWindowCount(
@@ -73,7 +73,40 @@ fun createRollingContextPlan(
 
 fun estimateContextTokens(messages: List<UIMessage>): Int = messages.sumOf(::estimateMessageTokens)
 
-fun estimateMessageTokens(message: UIMessage): Int = estimateTextTokens(message.toText()) + MESSAGE_OVERHEAD_TOKENS
+/**
+ * Estimates every token-bearing part retained in a message. Provider completion usage is used as
+ * a floor because it also captures hidden reasoning and protocol details absent from UI parts.
+ */
+@Suppress("DEPRECATION")
+fun estimateMessageTokens(message: UIMessage): Int {
+    val visibleTokens = message.parts.sumOf(::estimatePartTokens)
+    val producedTokens = message.usage?.completionTokens ?: 0
+    return maxOf(visibleTokens, producedTokens) + MESSAGE_OVERHEAD_TOKENS
+}
+
+/**
+ * Token estimate for the next provider request. A valid summary replaces its covered prefix; the
+ * latest provider prompt usage calibrates system prompts, documents and tool schemas that local
+ * tokenization may underestimate.
+ */
+fun estimateActiveContextTokens(
+    messages: List<UIMessage>,
+    storedSummary: RollingContextSummary?,
+): Int {
+    val coveredCount = storedSummary?.coveredMessageCount(messages) ?: 0
+    val validSummary = storedSummary?.takeIf { coveredCount > 0 }
+    val localEstimate = validSummary.orEmptySummaryTokens() +
+        estimateContextTokens(messages.drop(coveredCount))
+    val measuredMessageIndex = messages.indexOfLast { message ->
+        message.usage?.promptTokens?.let { it > 0 } == true &&
+            message.id !in validSummary?.sourceMessageIds.orEmpty()
+    }
+    val measuredEstimate = measuredMessageIndex.takeIf { it >= 0 }?.let { index ->
+        val usage = messages[index].usage ?: return@let null
+        usage.promptTokens + usage.completionTokens + estimateContextTokens(messages.drop(index + 1))
+    }
+    return maxOf(localEstimate, measuredEstimate ?: 0)
+}
 
 fun estimateTextTokens(text: String): Int {
     if (text.isBlank()) return 0
@@ -83,6 +116,32 @@ fun estimateTextTokens(text: String): Int {
 }
 
 private fun RollingContextSummary?.orEmptySummaryTokens(): Int = this?.content?.let(::estimateTextTokens) ?: 0
+
+@Suppress("DEPRECATION")
+private fun estimatePartTokens(part: UIMessagePart): Int = when (part) {
+    is UIMessagePart.Text -> estimateTextTokens(part.text)
+    is UIMessagePart.Reasoning -> estimateTextTokens(part.reasoning)
+    is UIMessagePart.Tool -> estimateTextTokens(part.toolCallId) +
+        estimateTextTokens(part.toolName) +
+        estimateTextTokens(part.input) +
+        part.output.sumOf(::estimatePartTokens)
+    is UIMessagePart.ServerTool -> estimateTextTokens(part.toolCallId) +
+        estimateTextTokens(part.toolName) +
+        estimateTextTokens(part.input?.toString().orEmpty()) +
+        estimateTextTokens(part.output?.toString().orEmpty())
+    is UIMessagePart.ToolCall -> estimateTextTokens(part.toolCallId) +
+        estimateTextTokens(part.toolName) +
+        estimateTextTokens(part.arguments)
+    is UIMessagePart.ToolResult -> estimateTextTokens(part.toolCallId) +
+        estimateTextTokens(part.toolName) +
+        estimateTextTokens(part.content.toString()) +
+        estimateTextTokens(part.arguments.toString())
+    is UIMessagePart.Image -> IMAGE_TOKEN_ESTIMATE
+    is UIMessagePart.Video -> VIDEO_TOKEN_ESTIMATE
+    is UIMessagePart.Audio -> AUDIO_TOKEN_ESTIMATE
+    is UIMessagePart.Document -> DOCUMENT_REFERENCE_TOKEN_ESTIMATE
+    UIMessagePart.Search -> 0
+}
 
 /**
  * Returns the first message index retained when a summary cannot be refreshed.
@@ -107,9 +166,10 @@ private fun List<UIMessage>.recentWindowCount(tokenBudget: Int): Int {
     }
 
     var startIndex = (size - count).coerceAtLeast(0)
-    // Tool outputs must retain the user turn that initiated their call.
-    while (startIndex > 0 && this[startIndex].role != MessageRole.USER) {
-        startIndex -= 1
+    // A request window should begin at the next complete user turn. Expanding backwards here can
+    // pull a very large document turn back into the request and defeat compression entirely.
+    while (startIndex < size && this[startIndex].role != MessageRole.USER) {
+        startIndex += 1
     }
     return size - startIndex
 }
@@ -119,8 +179,12 @@ private fun isCjkCharacter(character: Char): Boolean = character in '\u3040'..'\
     character in '\u4e00'..'\u9fff'
 
 private const val MESSAGE_OVERHEAD_TOKENS = 4
-private const val MIN_ROLLING_CONTEXT_MESSAGES = 4
-private const val MIN_RECENT_MESSAGE_COUNT = 4
+private const val DOCUMENT_REFERENCE_TOKEN_ESTIMATE = 32
+private const val IMAGE_TOKEN_ESTIMATE = 1_024
+private const val AUDIO_TOKEN_ESTIMATE = 4_096
+private const val VIDEO_TOKEN_ESTIMATE = 8_192
+private const val MIN_ROLLING_CONTEXT_MESSAGES = 1
+private const val MIN_RECENT_MESSAGE_COUNT = 1
 private const val RECENT_WINDOW_RATIO = 0.55f
 private const val SUMMARY_TARGET_DIVISOR = 4
 private const val MIN_SUMMARY_TOKENS = 512

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/DocumentAsPromptTransformer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/DocumentAsPromptTransformer.kt
@@ -1,7 +1,5 @@
 package me.rerere.rikkahub.data.ai.transformers
 
-import androidx.core.net.toFile
-import androidx.core.net.toUri
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import me.rerere.ai.ui.UIMessage
@@ -10,38 +8,52 @@ import me.rerere.document.DocxParser
 import me.rerere.document.EpubParser
 import me.rerere.document.PdfParser
 import me.rerere.document.PptxParser
+import me.rerere.document.XlsxParser
 import java.io.File
+import java.net.URI
+import java.util.LinkedHashMap
 
 object DocumentAsPromptTransformer : InputMessageTransformer {
+    private data class CacheKey(
+        val path: String,
+        val size: Long,
+        val lastModified: Long,
+    )
+
+    private val contentCache = object : LinkedHashMap<CacheKey, String>(16, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<CacheKey, String>?): Boolean =
+            size > MAX_CACHE_ENTRIES
+    }
+
     override suspend fun transform(
         ctx: TransformerContext,
         messages: List<UIMessage>,
-    ): List<UIMessage> {
-        return withContext(Dispatchers.IO) {
+    ): List<UIMessage> = transformDocumentContents(messages)
+
+    /** Used by rolling-context accounting so it sees the same text later sent to the provider. */
+    suspend fun transformDocumentContents(messages: List<UIMessage>): List<UIMessage> =
+        withContext(Dispatchers.IO) {
             messages.map { message ->
                 message.copy(
                     parts = message.parts.toMutableList().apply {
                         val documents = filterIsInstance<UIMessagePart.Document>()
-                        if (documents.isNotEmpty()) {
-                            documents.forEach { document ->
-                                val content = readDocumentContent(document)
-                                val path = resolveWorkspacePath(document)
-                                val pathAttr = path?.let { " path=\"$it\"" } ?: ""
-                                val prompt = """
-                                  <UploadFile name="${document.fileName}"$pathAttr>
-                                  ```
-                                  $content
-                                  ```
-                                  </UploadFile>
-                                  """.trimMargin()
-                                add(0, UIMessagePart.Text(prompt))
-                            }
+                        documents.asReversed().forEach { document ->
+                            val content = readDocumentContent(document)
+                            val path = resolveWorkspacePath(document)
+                            val pathAttr = path?.let { " path=\"${it.escapeXmlAttribute()}\"" } ?: ""
+                            val prompt = """
+                                <UploadFile name="${document.fileName.escapeXmlAttribute()}"$pathAttr>
+                                ```
+                                $content
+                                ```
+                                </UploadFile>
+                            """.trimIndent()
+                            add(0, UIMessagePart.Text(prompt))
                         }
                     }
                 )
             }
         }
-    }
 
     private fun parsePdfAsText(file: File): String {
         return PdfParser.parserPdf(file)
@@ -55,6 +67,10 @@ object DocumentAsPromptTransformer : InputMessageTransformer {
         return PptxParser.parse(file)
     }
 
+    private fun parseXlsxAsText(file: File): String {
+        return XlsxParser.parse(file)
+    }
+
     private fun parseEpubAsText(file: File): String {
         return EpubParser.parse(file)
     }
@@ -62,27 +78,55 @@ object DocumentAsPromptTransformer : InputMessageTransformer {
     // 上传文件保存在 filesDir/upload 下, 该目录通过 proot 挂载到 workspace 的 /upload
     // 返回文件在 workspace 内的绝对路径, 便于 AI 用 workspace 工具直接读取原始文件
     private fun resolveWorkspacePath(document: UIMessagePart.Document): String? {
-        val file = runCatching { document.url.toUri().toFile() }.getOrNull() ?: return null
+        val file = document.resolveLocalFile() ?: return null
         if (file.parentFile?.name != "upload") return null
         return "/upload/${file.name}"
     }
 
     private fun readDocumentContent(document: UIMessagePart.Document): String {
-        val file = runCatching { document.url.toUri().toFile() }.getOrNull()
+        val file = document.resolveLocalFile()
             ?: return "[ERROR, invalid file uri: ${document.fileName}]"
         if (!file.exists() || !file.isFile) {
             return "[ERROR, file not found: ${document.fileName}]"
         }
-        return runCatching {
-            when (document.mime) {
-                "application/pdf" -> parsePdfAsText(file)
-                "application/vnd.openxmlformats-officedocument.wordprocessingml.document" -> parseDocxAsText(file)
-                "application/vnd.openxmlformats-officedocument.presentationml.presentation" -> parsePptxAsText(file)
-                "application/epub+zip" -> parseEpubAsText(file)
+        val cacheKey = CacheKey(file.absolutePath, file.length(), file.lastModified())
+        synchronized(contentCache) { contentCache[cacheKey] }?.let { return it }
+
+        val content = runCatching {
+            val extension = document.fileName.substringAfterLast('.', "").lowercase()
+            val mime = document.mime.substringBefore(';').trim().lowercase()
+            when {
+                extension == "pdf" || mime == "application/pdf" -> parsePdfAsText(file)
+                extension == "docx" || mime == DOCX_MIME -> parseDocxAsText(file)
+                extension == "xlsx" || mime == XLSX_MIME -> parseXlsxAsText(file)
+                extension == "pptx" || mime == PPTX_MIME -> parsePptxAsText(file)
+                extension == "epub" || mime == EPUB_MIME -> parseEpubAsText(file)
                 else -> file.readText()
             }
         }.getOrElse {
-            "[ERROR, failed to read file: ${document.fileName}]"
+            "[ERROR, failed to read file: ${document.fileName}; ${it.message.orEmpty()}]"
         }
+        if (!content.startsWith("[ERROR,")) {
+            synchronized(contentCache) { contentCache[cacheKey] = content }
+        }
+        return content
     }
+
+    private fun UIMessagePart.Document.resolveLocalFile(): File? = runCatching {
+        when {
+            url.startsWith("file:", ignoreCase = true) -> File(URI(url))
+            else -> File(url)
+        }
+    }.getOrNull()
+
+    private fun String.escapeXmlAttribute(): String = replace("&", "&amp;")
+        .replace("\"", "&quot;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+
+    private const val MAX_CACHE_ENTRIES = 16
+    private const val DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    private const val XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    private const val PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    private const val EPUB_MIME = "application/epub+zip"
 }

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -553,6 +553,9 @@ class ChatService(
             } else {
                 conversation
             }
+            val contextGenerationMessages = DocumentAsPromptTransformer.transformDocumentContents(
+                generationMessages,
+            )
             val rollingSummary = preparedConversation.rollingContextSummary
                 ?.takeIf { it.coveredMessageCount(generationMessages) > 0 }
             val rollingSummaryMessageCount = rollingSummary?.coveredMessageCount(generationMessages) ?: 0
@@ -560,14 +563,14 @@ class ChatService(
                 assistant.rollingContextCompressionThresholdTokens,
             )
             val stillNeedsCompression = messageRange == null && createRollingContextPlan(
-                messages = generationMessages,
+                messages = contextGenerationMessages,
                 storedSummary = preparedConversation.rollingContextSummary,
                 thresholdTokens = rollingThresholdTokens,
             ) != null
             val requestMessageStartIndex = maxOf(
                 rollingSummaryMessageCount,
                 if (stillNeedsCompression) {
-                    rollingContextWindowStartIndex(generationMessages, rollingThresholdTokens)
+                    rollingContextWindowStartIndex(contextGenerationMessages, rollingThresholdTokens)
                 } else {
                     0
                 },
@@ -942,9 +945,12 @@ class ChatService(
         val thresholdTokens = effectiveRollingContextThreshold(
             assistant.rollingContextCompressionThresholdTokens,
         )
+        val contextMessages = DocumentAsPromptTransformer.transformDocumentContents(
+            conversation.currentMessages,
+        )
         if (
             createRollingContextPlan(
-                messages = conversation.currentMessages,
+                messages = contextMessages,
                 storedSummary = conversation.rollingContextSummary,
                 thresholdTokens = thresholdTokens,
             ) == null
@@ -961,6 +967,7 @@ class ChatService(
                 assistant = assistant,
                 settings = settings,
                 force = false,
+                planningMessages = contextMessages,
             ) ?: conversation
         } catch (error: CancellationException) {
             throw error
@@ -984,9 +991,12 @@ class ChatService(
         force: Boolean,
         targetTokensOverride: Int? = null,
         additionalPrompt: String = "",
+        planningMessages: List<UIMessage>? = null,
     ): Conversation? {
+        val messagesForPlanning = planningMessages
+            ?: DocumentAsPromptTransformer.transformDocumentContents(conversation.currentMessages)
         val plan = createRollingContextPlan(
-            messages = conversation.currentMessages,
+            messages = messagesForPlanning,
             storedSummary = conversation.rollingContextSummary,
             thresholdTokens = effectiveRollingContextThreshold(
                 assistant.rollingContextCompressionThresholdTokens,

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatContextUsage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatContextUsage.kt
@@ -15,12 +15,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import me.rerere.ai.ui.UIMessage
 import me.rerere.rikkahub.data.ai.context.RollingContextSummary
-import me.rerere.rikkahub.data.ai.context.createRollingContextPlan
-import me.rerere.rikkahub.data.ai.context.estimateTextTokens
-import me.rerere.rikkahub.data.ai.context.effectiveRollingContextThreshold
-import me.rerere.rikkahub.data.ai.context.coveredMessageCount
 import me.rerere.rikkahub.R
-import me.rerere.rikkahub.data.ai.context.estimateContextTokens
+import me.rerere.rikkahub.data.ai.context.estimateActiveContextTokens
 
 /** Context usage reflects the rolling request, not the complete locally retained history. */
 data class ChatContextUsage(
@@ -39,27 +35,10 @@ data class ChatContextUsage(
 internal fun calculateChatContextUsage(
     messages: List<UIMessage>,
     rollingContextSummary: RollingContextSummary? = null,
-    rollingContextThresholdTokens: Int = 0,
     capacityTokens: Int?,
 ): ChatContextUsage {
-    val coveredCount = rollingContextSummary?.coveredMessageCount(messages) ?: 0
-    val validSummary = rollingContextSummary?.takeIf { coveredCount > 0 }
-    val plannedRefresh = createRollingContextPlan(
-        messages = messages,
-        storedSummary = validSummary,
-        thresholdTokens = effectiveRollingContextThreshold(rollingContextThresholdTokens),
-    )
-    val summaryTokens = when {
-        plannedRefresh != null -> plannedRefresh.targetTokens
-        validSummary != null -> estimateTextTokens(validSummary.content)
-        else -> 0
-    }
-    val windowMessages = when {
-        plannedRefresh != null -> messages.drop(plannedRefresh.sourceMessageIds.size)
-        else -> messages.drop(coveredCount)
-    }
     return ChatContextUsage(
-        usedTokens = summaryTokens + estimateContextTokens(windowMessages),
+        usedTokens = estimateActiveContextTokens(messages, rollingContextSummary),
         capacityTokens = capacityTokens?.takeIf { it > 0 },
         isEstimated = true,
     )

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -69,6 +70,7 @@ import me.rerere.rikkahub.data.datastore.Settings
 import me.rerere.rikkahub.data.datastore.findProvider
 import me.rerere.rikkahub.data.datastore.getCurrentAssistant
 import me.rerere.rikkahub.data.datastore.getCurrentChatModel
+import me.rerere.rikkahub.data.ai.transformers.DocumentAsPromptTransformer
 import me.rerere.rikkahub.data.files.FilesManager
 import me.rerere.rikkahub.data.model.Assistant
 import me.rerere.rikkahub.data.model.Conversation
@@ -293,11 +295,22 @@ private fun ChatPageContent(
     var previewMode by rememberSaveable { mutableStateOf(false) }
     val hazeState = rememberHazeState()
     val assistant = setting.getCurrentAssistant()
-    val contextUsage = remember(conversation.currentMessages, currentChatModel?.contextWindowTokens) {
-        calculateChatContextUsage(
+    val contextUsage by produceState(
+        initialValue = calculateChatContextUsage(
             messages = conversation.currentMessages,
             rollingContextSummary = conversation.rollingContextSummary,
-            rollingContextThresholdTokens = assistant.rollingContextCompressionThresholdTokens,
+            capacityTokens = currentChatModel?.contextWindowTokens,
+        ),
+        conversation.currentMessages,
+        conversation.rollingContextSummary,
+        currentChatModel?.contextWindowTokens,
+    ) {
+        val contextMessages = DocumentAsPromptTransformer.transformDocumentContents(
+            conversation.currentMessages,
+        )
+        value = calculateChatContextUsage(
+            messages = contextMessages,
+            rollingContextSummary = conversation.rollingContextSummary,
             capacityTokens = currentChatModel?.contextWindowTokens,
         )
     }

--- a/app/src/main/java/me/rerere/rikkahub/utils/ChatUtil.kt
+++ b/app/src/main/java/me/rerere/rikkahub/utils/ChatUtil.kt
@@ -53,11 +53,13 @@ private val ALLOWED_FILE_EXTENSIONS = setOf(
     "c", "h", "cpp", "cc", "cxx", "hpp", "hh", "hxx",
     "rs", "cs", "markdown", "mdx",
     "toml", "ini", "env", "gradle", "kts", "properties",
-    "proto", "graphql", "gql", "yml", "yaml"
+    "proto", "graphql", "gql", "yml", "yaml",
+    "pdf", "docx", "xlsx", "pptx", "epub"
 )
 
 fun isAllowedFileType(fileName: String, mime: String): Boolean {
-    if (mime in ALLOWED_MIME_TYPES || mime.startsWith("text/")) return true
+    val normalizedMime = mime.substringBefore(';').trim().lowercase()
+    if (normalizedMime in ALLOWED_MIME_TYPES || normalizedMime.startsWith("text/")) return true
     val extension = fileName.substringAfterLast('.', "").lowercase()
     return extension in ALLOWED_FILE_EXTENSIONS
 }

--- a/app/src/test/java/me/rerere/rikkahub/data/ai/context/RollingContextTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/ai/context/RollingContextTest.kt
@@ -1,7 +1,9 @@
 package me.rerere.rikkahub.data.ai.context
 
 import me.rerere.ai.core.MessageRole
+import me.rerere.ai.core.TokenUsage
 import me.rerere.ai.ui.UIMessage
+import me.rerere.ai.ui.UIMessagePart
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -114,6 +116,71 @@ class RollingContextTest {
         assertTrue(startIndex < messages.lastIndex)
         assertEquals(MessageRole.USER, messages[startIndex].role)
         assertTrue(messages.drop(startIndex).size < messages.size)
+    }
+
+    @Test
+    fun `large prior turn can be compacted before four messages accumulate`() {
+        val messages = listOf(
+            UIMessage.user("document ${"x".repeat(20_000)}"),
+            UIMessage.assistant("I read the document."),
+            UIMessage.user("Continue."),
+        )
+
+        val plan = createRollingContextPlan(
+            messages = messages,
+            storedSummary = null,
+            thresholdTokens = 1_000,
+        )
+
+        assertNotNull(plan)
+        assertEquals(messages.take(2).map(UIMessage::id), plan!!.sourceMessageIds)
+        assertEquals(listOf(messages.last().id), messages.drop(plan.sourceMessageIds.size).map(UIMessage::id))
+    }
+
+    @Test
+    fun `reasoning and tool payloads are included in message estimate`() {
+        val message = UIMessage(
+            role = MessageRole.ASSISTANT,
+            parts = listOf(
+                UIMessagePart.Text("answer"),
+                UIMessagePart.Reasoning("r".repeat(400)),
+                UIMessagePart.Tool(
+                    toolCallId = "call-123",
+                    toolName = "inspect_file",
+                    input = "i".repeat(400),
+                    output = listOf(UIMessagePart.Text("o".repeat(400))),
+                ),
+            ),
+        )
+
+        assertTrue(estimateMessageTokens(message) > estimateMessageTokens(UIMessage.assistant("answer")) + 250)
+    }
+
+    @Test
+    fun `provider completion usage covers hidden model output`() {
+        val message = UIMessage.assistant("short answer").copy(
+            usage = TokenUsage(completionTokens = 2_000),
+        )
+
+        assertEquals(2_004, estimateMessageTokens(message))
+    }
+
+    @Test
+    fun `provider prompt usage can trigger automatic compression`() {
+        val messages = listOf(
+            UIMessage.assistant("Prior reply").copy(
+                usage = TokenUsage(promptTokens = 5_000, completionTokens = 100),
+            ),
+            UIMessage.user("Continue."),
+        )
+
+        assertNotNull(
+            createRollingContextPlan(
+                messages = messages,
+                storedSummary = null,
+                thresholdTokens = 4_000,
+            )
+        )
     }
 
     private fun messages(count: Int, contentLength: Int): List<UIMessage> = List(count) { index ->

--- a/app/src/test/java/me/rerere/rikkahub/data/ai/transformers/DocumentAsPromptTransformerTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/ai/transformers/DocumentAsPromptTransformerTest.kt
@@ -1,0 +1,85 @@
+package me.rerere.rikkahub.data.ai.transformers
+
+import kotlinx.coroutines.runBlocking
+import me.rerere.ai.ui.UIMessage
+import me.rerere.ai.ui.UIMessagePart
+import me.rerere.rikkahub.data.ai.context.createRollingContextPlan
+import me.rerere.rikkahub.ui.components.ai.calculateChatContextUsage
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class DocumentAsPromptTransformerTest {
+    @Test
+    fun `xlsx extension selects workbook parser when mime is generic`() = runBlocking {
+        val workbook = File.createTempFile("generic-mime-", ".xlsx").apply { deleteOnExit() }
+        ZipOutputStream(workbook.outputStream()).use { zip ->
+            zip.putNextEntry(ZipEntry("xl/worksheets/sheet1.xml"))
+            zip.write(
+                """
+                    <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                      <sheetData><row><c r="A1" t="inlineStr"><is><t>Quarterly revenue</t></is></c></row></sheetData>
+                    </worksheet>
+                """.trimIndent().toByteArray()
+            )
+            zip.closeEntry()
+        }
+        val message = UIMessage(
+            role = me.rerere.ai.core.MessageRole.USER,
+            parts = listOf(
+                UIMessagePart.Document(
+                    url = workbook.toURI().toString(),
+                    fileName = "financial-report.xlsx",
+                    mime = "application/octet-stream",
+                )
+            ),
+        )
+
+        val transformed = DocumentAsPromptTransformer.transformDocumentContents(listOf(message))
+        val prompt = transformed.single().parts.filterIsInstance<UIMessagePart.Text>().single().text
+
+        assertTrue(prompt.contains("## Sheet: Sheet 1"))
+        assertTrue(prompt.contains("Quarterly revenue"))
+        assertTrue(prompt.contains("<UploadFile name=\"financial-report.xlsx\""))
+    }
+
+    @Test
+    fun `parsed document text contributes to display and automatic compression`() = runBlocking {
+        val document = File.createTempFile("context-accounting-", ".txt").apply {
+            deleteOnExit()
+            writeText("document body ".repeat(2_000))
+        }
+        val sourceMessages = listOf(
+            UIMessage(
+                role = me.rerere.ai.core.MessageRole.USER,
+                parts = listOf(
+                    UIMessagePart.Document(
+                        url = document.toURI().toString(),
+                        fileName = "large-notes.txt",
+                        mime = "text/plain",
+                    )
+                ),
+            ),
+            UIMessage.assistant("I have read the file."),
+            UIMessage.user("Summarize it."),
+        )
+
+        val transformed = DocumentAsPromptTransformer.transformDocumentContents(sourceMessages)
+        val usage = calculateChatContextUsage(
+            messages = transformed,
+            capacityTokens = 32_000,
+        )
+
+        assertTrue(usage.usedTokens > 5_000)
+        assertNotNull(
+            createRollingContextPlan(
+                messages = transformed,
+                storedSummary = null,
+                thresholdTokens = 4_000,
+            )
+        )
+    }
+}

--- a/app/src/test/java/me/rerere/rikkahub/ui/components/ai/ChatContextUsageTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/ui/components/ai/ChatContextUsageTest.kt
@@ -9,16 +9,18 @@ import org.junit.Test
 
 class ChatContextUsageTest {
     @Test
-    fun `uses all active conversation messages instead of the latest truncated request`() {
+    fun `uses provider prompt usage when it exceeds the lightweight local estimate`() {
         val usage = calculateChatContextUsage(
             messages = listOf(
                 UIMessage.user("A much longer request that would produce a different local estimate."),
-                UIMessage.assistant("OK").copy(usage = TokenUsage(promptTokens = 12_345)),
+                UIMessage.assistant("OK").copy(
+                    usage = TokenUsage(promptTokens = 12_345, completionTokens = 25),
+                ),
             ),
             capacityTokens = 32_768,
         )
 
-        assertTrue(usage.usedTokens < 12_345)
+        assertEquals(12_370, usage.usedTokens)
         assertEquals(32_768, usage.capacityTokens)
         assertTrue(usage.isEstimated)
     }
@@ -46,7 +48,7 @@ class ChatContextUsageTest {
         )
 
         assertTrue(usage.isEstimated)
-        assertTrue(usage.usedTokens < 12_345)
+        assertTrue(usage.usedTokens > 12_345)
     }
 
     @Test
@@ -76,11 +78,25 @@ class ChatContextUsageTest {
         val usage = calculateChatContextUsage(
             messages = messages,
             rollingContextSummary = summary,
-            rollingContextThresholdTokens = 1_000,
             capacityTokens = 8_000,
         )
 
         assertTrue(usage.usedTokens < 1_500)
         assertTrue(usage.remainingTokens!! > 6_500)
+    }
+
+    @Test
+    fun `does not display a future compression result before compression succeeds`() {
+        val messages = List(6) { index ->
+            if (index % 2 == 0) UIMessage.user("message $index ${"x".repeat(4_000)}")
+            else UIMessage.assistant("message $index ${"x".repeat(4_000)}")
+        }
+
+        val usage = calculateChatContextUsage(
+            messages = messages,
+            capacityTokens = 32_768,
+        )
+
+        assertTrue(usage.usedTokens > 5_000)
     }
 }

--- a/app/src/test/java/me/rerere/rikkahub/utils/ChatUtilTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/utils/ChatUtilTest.kt
@@ -1,0 +1,23 @@
+package me.rerere.rikkahub.utils
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatUtilTest {
+    @Test
+    fun `office extensions are accepted when picker returns a generic mime`() {
+        assertTrue(isAllowedFileType("report.docx", "application/octet-stream"))
+        assertTrue(isAllowedFileType("budget.xlsx", "application/zip"))
+        assertTrue(isAllowedFileType("slides.pptx", "application/octet-stream"))
+    }
+
+    @Test
+    fun `mime matching ignores case and parameters`() {
+        assertTrue(
+            isAllowedFileType(
+                "download",
+                "Application/Vnd.Openxmlformats-Officedocument.Spreadsheetml.Sheet; charset=binary",
+            )
+        )
+    }
+}

--- a/document/src/main/java/me/rerere/document/DocxParser.kt
+++ b/document/src/main/java/me/rerere/document/DocxParser.kt
@@ -2,9 +2,13 @@ package me.rerere.document
 
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserFactory
+import org.xml.sax.Attributes
+import org.xml.sax.helpers.DefaultHandler
 import java.io.File
 import java.io.InputStream
 import java.util.zip.ZipInputStream
+import java.util.zip.ZipFile
+import javax.xml.parsers.SAXParserFactory
 
 private data class ListInfo(
     val level: Int,
@@ -19,13 +23,13 @@ private data class ParagraphProperties(
 
 object DocxParser {
     fun parse(file: File): String {
-        return try {
+        val primaryResult = try {
             file.inputStream().use { fileInputStream ->
                 ZipInputStream(fileInputStream).use { zipStream ->
                     var entry = zipStream.nextEntry
                     while (entry != null) {
                         if (entry.name == "word/document.xml") {
-                            return parseDocumentXml(zipStream)
+                            return@use parseDocumentXml(zipStream)
                         }
                         entry = zipStream.nextEntry
                     }
@@ -35,6 +39,61 @@ object DocxParser {
         } catch (e: Exception) {
             "Error parsing DOCX file: ${e.message}"
         }
+        if (primaryResult.isUsableDocumentText()) return primaryResult
+
+        return runCatching { parseDocumentXmlWithSax(file) }
+            .getOrElse { primaryResult }
+    }
+
+    private fun String.isUsableDocumentText(): Boolean = isNotBlank() &&
+        !startsWith("Error parsing", ignoreCase = true) &&
+        !startsWith("Unable to find", ignoreCase = true)
+
+    /** Plain-text fallback for vendor XML parser differences and malformed formatting metadata. */
+    private fun parseDocumentXmlWithSax(file: File): String = ZipFile(file).use { zip ->
+        val entry = zip.getEntry("word/document.xml")
+            ?: error("Unable to find document content in DOCX file")
+        val result = StringBuilder()
+        val paragraph = StringBuilder()
+        var inText = false
+        val factory = SAXParserFactory.newInstance().apply { isNamespaceAware = true }
+        runCatching { factory.setFeature("http://xml.org/sax/features/external-general-entities", false) }
+        runCatching { factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false) }
+        runCatching { factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true) }
+        zip.getInputStream(entry).use { input ->
+            factory.newSAXParser().parse(input, object : DefaultHandler() {
+                override fun startElement(
+                    uri: String?,
+                    localName: String?,
+                    qName: String?,
+                    attributes: Attributes?,
+                ) {
+                    when (localName?.takeIf(String::isNotBlank) ?: qName.orEmpty().substringAfter(':')) {
+                        "t" -> inText = true
+                        "tab" -> paragraph.append('\t')
+                        "br", "cr" -> paragraph.append('\n')
+                    }
+                }
+
+                override fun characters(characters: CharArray, start: Int, length: Int) {
+                    if (inText) paragraph.append(characters, start, length)
+                }
+
+                override fun endElement(uri: String?, localName: String?, qName: String?) {
+                    when (localName?.takeIf(String::isNotBlank) ?: qName.orEmpty().substringAfter(':')) {
+                        "t" -> inText = false
+                        "p" -> {
+                            paragraph.toString().trim().takeIf(String::isNotBlank)?.let { text ->
+                                if (result.isNotEmpty()) result.appendLine()
+                                result.append(text)
+                            }
+                            paragraph.clear()
+                        }
+                    }
+                }
+            })
+        }
+        result.toString().trim().ifBlank { error("No readable text found in DOCX file") }
     }
 
     private fun parseDocumentXml(inputStream: InputStream): String {

--- a/document/src/main/java/me/rerere/document/XlsxParser.kt
+++ b/document/src/main/java/me/rerere/document/XlsxParser.kt
@@ -1,0 +1,292 @@
+package me.rerere.document
+
+import org.xml.sax.Attributes
+import org.xml.sax.helpers.DefaultHandler
+import java.io.File
+import java.io.InputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import javax.xml.parsers.SAXParserFactory
+
+private data class WorkbookSheet(
+    val name: String,
+    val relationshipId: String,
+)
+
+/** Extracts readable, sheet-labelled TSV from an OOXML workbook without loading the workbook at once. */
+object XlsxParser {
+    fun parse(file: File): String = ZipFile(file).use { zip ->
+        val sharedStrings = zip.getEntry(SHARED_STRINGS_PATH)?.let { entry ->
+            zip.getInputStream(entry).use(::parseSharedStrings)
+        }.orEmpty()
+        val relationships = zip.getEntry(WORKBOOK_RELS_PATH)?.let { entry ->
+            zip.getInputStream(entry).use(::parseRelationships)
+        }.orEmpty()
+        val workbookSheets = zip.getEntry(WORKBOOK_PATH)?.let { entry ->
+            zip.getInputStream(entry).use(::parseWorkbook)
+        }.orEmpty()
+
+        val sheets = workbookSheets.mapNotNull { sheet ->
+            val path = relationships[sheet.relationshipId] ?: return@mapNotNull null
+            zip.getEntry(path)?.let { entry -> sheet.name to entry }
+        }.ifEmpty {
+            zip.entries().toList()
+                .filter { it.name.matches(WORKSHEET_PATH_PATTERN) }
+                .sortedBy(::worksheetNumber)
+                .mapIndexed { index, entry -> "Sheet ${index + 1}" to entry }
+        }
+
+        require(sheets.isNotEmpty()) { "No worksheets found in XLSX file" }
+        buildString {
+            for ((sheetName, entry) in sheets) {
+                if (length >= MAX_WORKBOOK_OUTPUT_CHARS) break
+                if (isNotEmpty()) appendLine()
+                append("## Sheet: ")
+                appendLine(sheetName.replace('\n', ' ').replace('\r', ' '))
+                appendLine()
+                val remaining = MAX_WORKBOOK_OUTPUT_CHARS - length
+                append(
+                    zip.getInputStream(entry).use { stream ->
+                        parseWorksheet(stream, sharedStrings, remaining)
+                    }
+                )
+            }
+            if (length >= MAX_WORKBOOK_OUTPUT_CHARS) {
+                setLength(MAX_WORKBOOK_OUTPUT_CHARS)
+                appendLine()
+                append("[Workbook content truncated after $MAX_WORKBOOK_OUTPUT_CHARS characters]")
+            }
+        }.trim()
+    }
+
+    private fun parseWorkbook(input: InputStream): List<WorkbookSheet> {
+        val sheets = mutableListOf<WorkbookSheet>()
+        parseXml(input, object : DefaultHandler() {
+            override fun startElement(uri: String?, localName: String?, qName: String?, attributes: Attributes) {
+                if (elementName(localName, qName) != "sheet") return
+                val name = attributes.value("name").orEmpty()
+                val relationshipId = attributes.value("id").orEmpty()
+                if (name.isNotBlank() && relationshipId.isNotBlank()) {
+                    sheets += WorkbookSheet(name, relationshipId)
+                }
+            }
+        })
+        return sheets
+    }
+
+    private fun parseRelationships(input: InputStream): Map<String, String> {
+        val relationships = mutableMapOf<String, String>()
+        parseXml(input, object : DefaultHandler() {
+            override fun startElement(uri: String?, localName: String?, qName: String?, attributes: Attributes) {
+                if (elementName(localName, qName) != "Relationship") return
+                val id = attributes.value("Id")
+                val target = attributes.value("Target")
+                if (!id.isNullOrBlank() && !target.isNullOrBlank()) {
+                    relationships[id] = normalizeWorkbookTarget(target)
+                }
+            }
+        })
+        return relationships
+    }
+
+    private fun parseSharedStrings(input: InputStream): List<String> {
+        val strings = mutableListOf<String>()
+        parseXml(input, object : DefaultHandler() {
+            private var current: StringBuilder? = null
+            private var inText = false
+
+            override fun startElement(uri: String?, localName: String?, qName: String?, attributes: Attributes?) {
+                when (elementName(localName, qName)) {
+                    "si" -> current = StringBuilder()
+                    "t" -> if (current != null) inText = true
+                }
+            }
+
+            override fun characters(characters: CharArray, start: Int, length: Int) {
+                if (!inText) return
+                val builder = current ?: return
+                val remaining = MAX_SHARED_STRING_CHARS - builder.length
+                if (remaining > 0) builder.append(characters, start, minOf(length, remaining))
+            }
+
+            override fun endElement(uri: String?, localName: String?, qName: String?) {
+                when (elementName(localName, qName)) {
+                    "t" -> inText = false
+                    "si" -> {
+                        strings += current?.toString().orEmpty()
+                        current = null
+                    }
+                }
+            }
+        })
+        return strings
+    }
+
+    private fun parseWorksheet(
+        input: InputStream,
+        sharedStrings: List<String>,
+        maxOutputChars: Int,
+    ): String {
+        val output = StringBuilder()
+        var truncated = false
+        parseXml(input, object : DefaultHandler() {
+            private var rowCells = sortedMapOf<Int, String>()
+            private var cellColumn = -1
+            private var cellType = ""
+            private var cellValue = StringBuilder()
+            private var inlineValue = StringBuilder()
+            private var formula = StringBuilder()
+            private var capture: String? = null
+
+            override fun startElement(uri: String?, localName: String?, qName: String?, attributes: Attributes) {
+                if (truncated) return
+                when (elementName(localName, qName)) {
+                    "row" -> rowCells = sortedMapOf()
+                    "c" -> {
+                        cellColumn = columnIndex(attributes.value("r").orEmpty())
+                        cellType = attributes.value("t").orEmpty()
+                        cellValue = StringBuilder()
+                        inlineValue = StringBuilder()
+                        formula = StringBuilder()
+                    }
+                    "v" -> capture = "v"
+                    "f" -> capture = "f"
+                    "t" -> if (cellColumn >= 0) capture = "t"
+                }
+            }
+
+            override fun characters(characters: CharArray, start: Int, length: Int) {
+                if (truncated) return
+                when (capture) {
+                    "v" -> cellValue.append(characters, start, length)
+                    "f" -> formula.append(characters, start, length)
+                    "t" -> inlineValue.append(characters, start, length)
+                }
+            }
+
+            override fun endElement(uri: String?, localName: String?, qName: String?) {
+                if (truncated) return
+                when (elementName(localName, qName)) {
+                    "v", "f", "t" -> capture = null
+                    "c" -> if (cellColumn in 0 until MAX_EXCEL_COLUMNS) {
+                        rowCells[cellColumn] = formatCellValue(
+                            type = cellType,
+                            rawValue = cellValue.toString(),
+                            inlineValue = inlineValue.toString(),
+                            formula = formula.toString(),
+                            sharedStrings = sharedStrings,
+                        )
+                    }
+                    "row" -> if (rowCells.isNotEmpty()) {
+                        appendRow(output, rowCells)
+                        truncated = output.length >= maxOutputChars
+                    }
+                }
+            }
+        })
+
+        if (output.length > maxOutputChars) output.setLength(maxOutputChars)
+        if (truncated) {
+            output.appendLine()
+            output.append("[Worksheet content truncated]")
+        }
+        return output.toString().trimEnd()
+    }
+
+    private fun formatCellValue(
+        type: String,
+        rawValue: String,
+        inlineValue: String,
+        formula: String,
+        sharedStrings: List<String>,
+    ): String {
+        val value = when (type) {
+            "s" -> rawValue.toIntOrNull()?.let(sharedStrings::getOrNull) ?: rawValue
+            "inlineStr" -> inlineValue
+            "b" -> if (rawValue == "1") "TRUE" else "FALSE"
+            else -> inlineValue.ifBlank { rawValue }
+        }.sanitizeCell()
+        val normalizedFormula = formula.sanitizeCell()
+        return when {
+            normalizedFormula.isBlank() -> value
+            value.isBlank() -> "=$normalizedFormula"
+            else -> "=$normalizedFormula -> $value"
+        }
+    }
+
+    private fun appendRow(output: StringBuilder, cells: Map<Int, String>) {
+        val lastColumn = cells.keys.maxOrNull() ?: return
+        for (column in 0..lastColumn) {
+            if (column > 0) output.append('\t')
+            output.append(cells[column].orEmpty())
+        }
+        output.appendLine()
+    }
+
+    private fun columnIndex(reference: String): Int {
+        var value = 0
+        var found = false
+        for (character in reference) {
+            if (!character.isLetter()) break
+            found = true
+            value = value * 26 + (character.uppercaseChar() - 'A' + 1)
+        }
+        return if (found) value - 1 else -1
+    }
+
+    private fun normalizeWorkbookTarget(target: String): String {
+        val raw = if (target.startsWith('/')) target.drop(1) else "xl/$target"
+        val segments = ArrayDeque<String>()
+        raw.split('/').forEach { segment ->
+            when (segment) {
+                "", "." -> Unit
+                ".." -> if (segments.isNotEmpty()) segments.removeLast()
+                else -> segments.addLast(segment)
+            }
+        }
+        return segments.joinToString("/")
+    }
+
+    private fun parseXml(input: InputStream, handler: DefaultHandler) {
+        val factory = SAXParserFactory.newInstance().apply {
+            isNamespaceAware = true
+        }
+        // Android vendors expose slightly different SAX feature sets. Apply every hardening flag
+        // supported by the current parser without making valid local workbooks unparseable.
+        runCatching { factory.setFeature("http://xml.org/sax/features/external-general-entities", false) }
+        runCatching { factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false) }
+        runCatching { factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true) }
+        factory.newSAXParser().parse(input, handler)
+    }
+
+    private fun Attributes.value(localName: String): String? {
+        for (index in 0 until length) {
+            if (getLocalName(index).equals(localName, ignoreCase = true) ||
+                getQName(index).substringAfter(':').equals(localName, ignoreCase = true)
+            ) {
+                return getValue(index)
+            }
+        }
+        return null
+    }
+
+    private fun elementName(localName: String?, qualifiedName: String?): String =
+        localName?.takeIf(String::isNotBlank) ?: qualifiedName.orEmpty().substringAfter(':')
+
+    private fun String.sanitizeCell(): String = replace('\t', ' ')
+        .replace("\r\n", "\\n")
+        .replace('\r', '\n')
+        .replace("\n", "\\n")
+        .trim()
+
+    private fun worksheetNumber(entry: ZipEntry): Int =
+        entry.name.substringAfterLast("sheet").substringBefore('.').toIntOrNull() ?: Int.MAX_VALUE
+
+    private const val WORKBOOK_PATH = "xl/workbook.xml"
+    private const val WORKBOOK_RELS_PATH = "xl/_rels/workbook.xml.rels"
+    private const val SHARED_STRINGS_PATH = "xl/sharedStrings.xml"
+    private val WORKSHEET_PATH_PATTERN = Regex("xl/worksheets/sheet\\d+\\.xml")
+    private const val MAX_EXCEL_COLUMNS = 16_384
+    private const val MAX_SHARED_STRING_CHARS = 100_000
+    private const val MAX_WORKBOOK_OUTPUT_CHARS = 1_000_000
+}

--- a/document/src/test/java/me/rerere/document/DocxParserTest.kt
+++ b/document/src/test/java/me/rerere/document/DocxParserTest.kt
@@ -1,0 +1,33 @@
+package me.rerere.document
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class DocxParserTest {
+    @Test
+    fun `extracts text when the platform pull parser is unavailable`() {
+        val document = File.createTempFile("docx-parser-", ".docx").apply { deleteOnExit() }
+        ZipOutputStream(document.outputStream()).use { zip ->
+            zip.putNextEntry(ZipEntry("word/document.xml"))
+            zip.write(
+                """
+                    <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                      <w:body>
+                        <w:p><w:r><w:t>Project report</w:t></w:r></w:p>
+                        <w:p><w:r><w:t>Second paragraph</w:t></w:r></w:p>
+                      </w:body>
+                    </w:document>
+                """.trimIndent().toByteArray()
+            )
+            zip.closeEntry()
+        }
+
+        val parsed = DocxParser.parse(document)
+
+        assertTrue(parsed.contains("Project report"))
+        assertTrue(parsed.contains("Second paragraph"))
+    }
+}

--- a/document/src/test/java/me/rerere/document/XlsxParserTest.kt
+++ b/document/src/test/java/me/rerere/document/XlsxParserTest.kt
@@ -1,0 +1,88 @@
+package me.rerere.document
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class XlsxParserTest {
+    @Test
+    fun `parses shared strings inline values formulas and multiple sheets`() {
+        val workbook = createWorkbook(
+            mapOf(
+                "xl/workbook.xml" to """
+                    <workbook xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+                      <sheets>
+                        <sheet name="Summary" r:id="rId1"/>
+                        <sheet name="Details" r:id="rId2"/>
+                      </sheets>
+                    </workbook>
+                """.trimIndent(),
+                "xl/_rels/workbook.xml.rels" to """
+                    <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+                      <Relationship Id="rId1" Target="worksheets/sheet1.xml"/>
+                      <Relationship Id="rId2" Target="worksheets/sheet2.xml"/>
+                    </Relationships>
+                """.trimIndent(),
+                "xl/sharedStrings.xml" to """
+                    <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                      <si><t>Name</t></si>
+                      <si><r><t>Total</t></r><r><t> amount</t></r></si>
+                    </sst>
+                """.trimIndent(),
+                "xl/worksheets/sheet1.xml" to """
+                    <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                      <sheetData>
+                        <row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c></row>
+                        <row r="2"><c r="A2" t="inlineStr"><is><t>Alpha</t></is></c><c r="B2"><f>SUM(B3:B4)</f><v>42</v></c></row>
+                      </sheetData>
+                    </worksheet>
+                """.trimIndent(),
+                "xl/worksheets/sheet2.xml" to """
+                    <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                      <sheetData><row r="1"><c r="A1" t="b"><v>1</v></c></row></sheetData>
+                    </worksheet>
+                """.trimIndent(),
+            )
+        )
+
+        val parsed = XlsxParser.parse(workbook)
+
+        assertTrue(parsed.contains("## Sheet: Summary"))
+        assertTrue(parsed.contains("Name\tTotal amount"))
+        assertTrue(parsed.contains("Alpha\t=SUM(B3:B4) -> 42"))
+        assertTrue(parsed.contains("## Sheet: Details"))
+        assertTrue(parsed.contains("TRUE"))
+    }
+
+    @Test
+    fun `falls back to worksheet entries when workbook relationships are absent`() {
+        val workbook = createWorkbook(
+            mapOf(
+                "xl/worksheets/sheet1.xml" to """
+                    <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                      <sheetData><row><c r="A1" t="inlineStr"><is><t>Visible</t></is></c></row></sheetData>
+                    </worksheet>
+                """.trimIndent(),
+            )
+        )
+
+        val parsed = XlsxParser.parse(workbook)
+
+        assertTrue(parsed.contains("## Sheet: Sheet 1"))
+        assertTrue(parsed.contains("Visible"))
+    }
+
+    private fun createWorkbook(entries: Map<String, String>): File {
+        val file = File.createTempFile("xlsx-parser-", ".xlsx").apply { deleteOnExit() }
+        ZipOutputStream(file.outputStream()).use { zip ->
+            entries.forEach { (name, content) ->
+                zip.putNextEntry(ZipEntry(name))
+                zip.write(content.toByteArray())
+                zip.closeEntry()
+            }
+        }
+        return file
+    }
+}


### PR DESCRIPTION
## Changes / 更新内容

- Add reliable DOCX fallback parsing and XLSX text extraction, including generic MIME and extension-based recognition.
- 新增可靠的 DOCX 回退解析与 XLSX 文本提取，并支持通用 MIME 与扩展名识别。
- Count user text, model replies, reasoning, tool payloads, media estimates, parsed document content, and provider token usage in active-context estimates.
- 上下文统计覆盖用户文本、模型回复、推理内容、工具载荷、媒体估算、文档解析文本及供应商返回的 Token 用量。
- Use parsed document content for context display and automatic compression planning, including large early turns.
- 上下文显示与自动压缩规划统一使用文档解析后的内容，并支持在早期大体积消息达到阈值时触发压缩。

## Validation / 验证

- Passed focused DOCX/XLSX parser tests and application tests for document prompts, context accounting, compression planning, and Office file recognition.
- 已通过 DOCX/XLSX 解析测试，以及文档提示词、上下文统计、压缩规划和 Office 文件识别相关应用测试。
