### PR TITLE
[codex] improve model capability and context discovery / 优化模型能力与上下文窗口识别

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/ModelContextWindow.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/ModelContextWindow.kt
@@ -22,6 +22,12 @@ private val CONTEXT_WINDOW_FIELDS = listOf(
     "max_input_tokens",
     "maxSequenceLength",
     "max_sequence_length",
+    "maxModelLength",
+    "max_model_len",
+    "maxPositionEmbeddings",
+    "max_position_embeddings",
+    "tokenLimit",
+    "token_limit",
 )
 
 private val CONTEXT_WINDOW_CONTAINERS = listOf(
@@ -34,6 +40,13 @@ private val CONTEXT_WINDOW_CONTAINERS = listOf(
     "top_provider",
 )
 
+private val NORMALIZED_CONTEXT_WINDOW_FIELDS = CONTEXT_WINDOW_FIELDS.mapTo(mutableSetOf()) {
+    it.normalizedMetadataKey()
+}
+private val NORMALIZED_CONTEXT_WINDOW_CONTAINERS = CONTEXT_WINDOW_CONTAINERS.mapTo(mutableSetOf()) {
+    it.normalizedMetadataKey()
+}
+
 internal enum class ModelDiscoveryProtocol {
     OPENAI,
     GOOGLE,
@@ -45,11 +58,15 @@ internal enum class ModelDiscoveryProtocol {
  * Providers that do not expose a capacity leave the value unset so it can still be configured manually.
  */
 internal fun JsonObject.contextWindowTokensOrNull(): Int? {
-    CONTEXT_WINDOW_FIELDS.forEach { field ->
-        this[field].contextWindowTokenCountOrNull()?.let { return it }
+    entries.forEach { (field, value) ->
+        if (field.normalizedMetadataKey() in NORMALIZED_CONTEXT_WINDOW_FIELDS) {
+            value.contextWindowTokenCountOrNull()?.let { return it }
+        }
     }
-    CONTEXT_WINDOW_CONTAINERS.forEach { container ->
-        (this[container] as? JsonObject)?.contextWindowTokensOrNull()?.let { return it }
+    entries.forEach { (container, value) ->
+        if (container.normalizedMetadataKey() in NORMALIZED_CONTEXT_WINDOW_CONTAINERS) {
+            (value as? JsonObject)?.contextWindowTokensOrNull()?.let { return it }
+        }
     }
     return null
 }
@@ -75,9 +92,9 @@ fun mergeDiscoveredContextWindows(
     configuredModels: List<Model>,
     discoveredModels: List<Model>,
 ): List<Model> {
-    val discoveredById = discoveredModels.associateBy(Model::modelId)
+    val discoveredById = discoveredModels.associateBy { it.modelId.normalizedModelId() }
     return configuredModels.map { configured ->
-        val discoveredTokens = discoveredById[configured.modelId]?.contextWindowTokens
+        val discoveredTokens = discoveredById[configured.modelId.normalizedModelId()]?.contextWindowTokens
         if (configured.contextWindowTokens == null && discoveredTokens != null) {
             configured.copy(contextWindowTokens = discoveredTokens)
         } else {
@@ -85,6 +102,12 @@ fun mergeDiscoveredContextWindows(
         }
     }
 }
+
+/** Returns a conservative known capacity for manual model configuration. */
+fun inferContextWindowTokens(modelId: String): Int? =
+    knownOpenAIContextWindowTokens(modelId)
+        ?: knownGoogleContextWindowTokens(modelId)
+        ?: knownAnthropicContextWindowTokens(modelId)
 
 /** Parses the compact K/M notation accepted by the manual context-window setting. */
 fun parseContextWindowTokens(value: String): Int? {
@@ -115,6 +138,8 @@ private fun JsonElement?.contextWindowTokenCountOrNull(): Int? {
 private fun knownOpenAIContextWindowTokens(modelId: String): Int? {
     val id = modelId.normalizedModelId()
     return when {
+        id.startsWith("gpt-5.4-mini") || id.startsWith("gpt-5.4-nano") -> 400_000
+        id.startsWith("gpt-5.4") || id.startsWith("gpt-5.5") || id.startsWith("gpt-5.6") -> 1_050_000
         id.startsWith("gpt-5") -> 400_000
         id.startsWith("gpt-4.1") -> 1_047_576
         id.startsWith("o1") || id.startsWith("o3") || id.startsWith("o4") -> 200_000
@@ -132,6 +157,9 @@ private fun knownOpenAIContextWindowTokens(modelId: String): Int? {
 private fun knownGoogleContextWindowTokens(modelId: String): Int? {
     val id = modelId.normalizedModelId()
     return when {
+        id.startsWith("gemini-3.1-flash-image") -> 131_072
+        id.startsWith("gemini-3-pro-image") -> 65_536
+        id.startsWith("gemini-2.5-flash-image") -> 65_536
         id.startsWith("gemini-1.5-pro") -> 2_097_152
         id == "gemini-pro" || id.startsWith("gemini-1.0-pro") -> 30_720
         id.startsWith("gemini-") -> 1_048_576
@@ -141,7 +169,14 @@ private fun knownGoogleContextWindowTokens(modelId: String): Int? {
 
 private fun knownAnthropicContextWindowTokens(modelId: String): Int? {
     val id = modelId.normalizedModelId()
+    val tokens = id.split(MODEL_ID_SEPARATOR).filter(String::isNotEmpty)
     return when {
+        tokens.matchesClaudeFamilyVersion("opus", major = "5") ||
+            tokens.matchesClaudeFamilyVersion("sonnet", major = "5") ||
+            tokens.matchesClaudeFamilyVersion("fable", major = "5") ||
+            tokens.matchesClaudeFamilyVersion("mythos", major = "5") ||
+            tokens.matchesClaudeFamilyVersion("opus", major = "4", minor = setOf("6", "7", "8")) ||
+            tokens.matchesClaudeFamilyVersion("sonnet", major = "4", minor = setOf("6")) -> 1_000_000
         id.startsWith("claude-2.1") -> 200_000
         id.startsWith("claude-2") || id.startsWith("claude-instant") -> 100_000
         id.startsWith("claude-") -> 200_000
@@ -151,5 +186,26 @@ private fun knownAnthropicContextWindowTokens(modelId: String): Int? {
 
 private fun String.normalizedModelId(): String = substringAfterLast('/').trim().lowercase()
 
+private fun String.normalizedMetadataKey(): String = filter(Char::isLetterOrDigit).lowercase()
+
+private fun List<String>.matchesClaudeFamilyVersion(
+    family: String,
+    major: String,
+    minor: Set<String>? = null,
+): Boolean {
+    if ("claude" !in this) return false
+    return if (minor == null) {
+        windowed(size = 2).any { it == listOf(family, major) || it == listOf(major, family) }
+    } else {
+        windowed(size = 3).any { tokens ->
+            minor.any { minorVersion ->
+                tokens == listOf(family, major, minorVersion) ||
+                    tokens == listOf(major, minorVersion, family)
+            }
+        }
+    }
+}
+
 private const val MAX_CONTEXT_WINDOW_TOKENS = 10_000_000L
 private val CONTEXT_WINDOW_INPUT = Regex("^(\\d+)([kKmM])?$")
+private val MODEL_ID_SEPARATOR = Regex("[-_.]+")

--- a/ai/src/main/java/me/rerere/ai/provider/ModelInference.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/ModelInference.kt
@@ -1,0 +1,68 @@
+package me.rerere.ai.provider
+
+/**
+ * Infers the primary model role from identifiers used by official and compatible APIs.
+ * Unknown identifiers stay as chat models so users can still configure them manually.
+ */
+fun inferModelTypeFromId(modelId: String): ModelType {
+    val id = modelId.substringAfterLast('/').trim().lowercase()
+    if (id.isEmpty()) return ModelType.CHAT
+
+    val tokens = id.split(MODEL_TOKEN_SEPARATOR).filter(String::isNotEmpty).toSet()
+    if (
+        id.contains("embedding") ||
+        id.contains("embed") ||
+        EMBEDDING_MODEL_TOKENS.any(tokens::contains) ||
+        id.startsWith("bge-") ||
+        id.startsWith("e5-") ||
+        id.startsWith("gte-") ||
+        id.contains("mxbai") ||
+        id.contains("nomic-embed") ||
+        id.contains("jina-embeddings")
+    ) {
+        return ModelType.EMBEDDING
+    }
+
+    val isGeminiImage = id.startsWith("gemini-") && IMAGE_TOKEN.containsMatchIn(id)
+    val isGrokImage = id.startsWith("grok-") && IMAGE_TOKEN.containsMatchIn(id)
+    if (
+        isGeminiImage ||
+        isGrokImage ||
+        IMAGE_MODEL_MARKERS.any(id::contains)
+    ) {
+        return ModelType.IMAGE
+    }
+
+    return ModelType.CHAT
+}
+
+private val MODEL_TOKEN_SEPARATOR = Regex("[-_./]+")
+private val IMAGE_TOKEN = Regex("(?:^|[-_./])image(?:$|[-_./])")
+private val EMBEDDING_MODEL_TOKENS = setOf("bge", "e5", "gte")
+private val IMAGE_MODEL_MARKERS = listOf(
+    "gpt-image",
+    "dall-e",
+    "imagen",
+    "image-generation",
+    "imagegeneration",
+    "nano-banana",
+    "nanobanana",
+    "flux",
+    "stable-diffusion",
+    "stable_image",
+    "sdxl",
+    "seedream",
+    "jimeng",
+    "dreamina",
+    "cogview",
+    "kolors",
+    "qwen-image",
+    "wanx",
+    "hunyuan-image",
+    "hidream",
+    "z-image",
+    "midjourney",
+    "ideogram",
+    "recraft",
+    "kandinsky",
+)

--- a/ai/src/main/java/me/rerere/ai/provider/providers/claude/ClaudeProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/claude/ClaudeProvider.kt
@@ -43,6 +43,7 @@ import me.rerere.ai.provider.ProviderSetting
 import me.rerere.ai.provider.TextGenerationResult
 import me.rerere.ai.provider.TextGenerationParams
 import me.rerere.ai.provider.contextWindowTokensOrNull
+import me.rerere.ai.registry.ModelRegistry
 import me.rerere.ai.provider.providers.PartGroup
 import me.rerere.ai.provider.providers.groupPartsByToolBoundary
 import me.rerere.ai.provider.stream.SseEvent
@@ -270,7 +271,7 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
     override suspend fun listModels(providerSetting: ProviderSetting.Claude): List<Model> =
         withContext(Dispatchers.IO) {
             val request = Request.Builder()
-                .url("${providerSetting.baseUrl}/models")
+                .url("${providerSetting.baseUrl}/models?limit=1000")
                 .addHeader("x-api-key", keyRoulette.next(providerSetting.apiKey, providerSetting.id.toString()))
                 .addHeader("anthropic-version", ANTHROPIC_VERSION)
                 .get()
@@ -293,6 +294,10 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
                 Model(
                     modelId = id,
                     displayName = displayName,
+                    type = ModelRegistry.MODEL_TYPE.getData(id),
+                    inputModalities = ModelRegistry.MODEL_INPUT_MODALITIES.getData(id),
+                    outputModalities = ModelRegistry.MODEL_OUTPUT_MODALITIES.getData(id),
+                    abilities = ModelRegistry.MODEL_ABILITIES.getData(id),
                     contextWindowTokens = modelObj.contextWindowTokensOrNull(
                         modelId = id,
                         protocol = ModelDiscoveryProtocol.ANTHROPIC,

--- a/ai/src/main/java/me/rerere/ai/provider/providers/google/GoogleProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/google/GoogleProvider.kt
@@ -40,6 +40,7 @@ import me.rerere.ai.provider.ModelAbility
 import me.rerere.ai.provider.ModelType
 import me.rerere.ai.provider.Provider
 import me.rerere.ai.provider.ProviderSetting
+import me.rerere.ai.provider.inferModelTypeFromId
 import me.rerere.ai.provider.TextGenerationResult
 import me.rerere.ai.provider.TextGenerationParams
 import me.rerere.ai.provider.contextWindowTokensOrNull
@@ -125,7 +126,7 @@ class GoogleProvider(private val client: OkHttpClient, context: Context? = null)
 
     override suspend fun listModels(providerSetting: ProviderSetting.Google): List<Model> =
         withContext(Dispatchers.IO) {
-            val url = buildUrl(providerSetting = providerSetting, path = "models?pageSize=100")
+            val url = buildUrl(providerSetting = providerSetting, path = "models?pageSize=1000")
             val request = transformRequest(
                 providerSetting = providerSetting,
                 request = Request.Builder()
@@ -142,20 +143,27 @@ class GoogleProvider(private val client: OkHttpClient, context: Context? = null)
                 models.mapNotNull {
                     val modelObject = it.jsonObject
 
-                    // 忽略非chat/embedding模型
                     val supportedGenerationMethods =
-                        modelObject["supportedGenerationMethods"]!!.jsonArray
-                            .map { method -> method.jsonPrimitive.content }
-                    if ("generateContent" !in supportedGenerationMethods && "embedContent" !in supportedGenerationMethods) {
+                        (modelObject["supportedGenerationMethods"] as? JsonArray)
+                            .orEmpty()
+                            .mapNotNull { method -> method.jsonPrimitive.contentOrNull }
+                    val fullModelId = modelObject["name"]?.jsonPrimitive?.contentOrNull
+                        ?: return@mapNotNull null
+                    val modelId = fullModelId.substringAfter("/")
+                    val modelType = inferGoogleModelType(modelId, supportedGenerationMethods)
+                    if (modelType == null) {
                         return@mapNotNull null
                     }
 
                     Model(
-                        modelId = modelObject["name"]!!.jsonPrimitive.content.substringAfter("/"),
-                        displayName = modelObject["displayName"]!!.jsonPrimitive.content,
-                        type = if ("generateContent" in supportedGenerationMethods) ModelType.CHAT else ModelType.EMBEDDING,
+                        modelId = modelId,
+                        displayName = modelObject["displayName"]?.jsonPrimitive?.contentOrNull ?: modelId,
+                        type = modelType,
+                        inputModalities = ModelRegistry.MODEL_INPUT_MODALITIES.getData(modelId),
+                        outputModalities = ModelRegistry.MODEL_OUTPUT_MODALITIES.getData(modelId),
+                        abilities = ModelRegistry.MODEL_ABILITIES.getData(modelId),
                         contextWindowTokens = modelObject.contextWindowTokensOrNull(
-                            modelId = modelObject["name"]!!.jsonPrimitive.content,
+                            modelId = fullModelId,
                             protocol = ModelDiscoveryProtocol.GOOGLE,
                         ),
                     )
@@ -875,5 +883,19 @@ class GoogleProvider(private val client: OkHttpClient, context: Context? = null)
             totalTokens = totalTokens,
             cachedTokens = cachedTokens
         )
+    }
+}
+
+internal fun inferGoogleModelType(
+    modelId: String,
+    supportedGenerationMethods: List<String>,
+): ModelType? = when (inferModelTypeFromId(modelId)) {
+    ModelType.IMAGE -> ModelType.IMAGE
+    ModelType.EMBEDDING -> ModelType.EMBEDDING
+    ModelType.CHAT -> when {
+        "embedContent" in supportedGenerationMethods && "generateContent" !in supportedGenerationMethods ->
+            ModelType.EMBEDDING
+        "generateContent" in supportedGenerationMethods -> ModelType.CHAT
+        else -> null
     }
 }

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/OpenAIProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/OpenAIProvider.kt
@@ -29,7 +29,9 @@ import me.rerere.ai.provider.ProviderSetting
 import me.rerere.ai.provider.TextGenerationResult
 import me.rerere.ai.provider.TextGenerationParams
 import me.rerere.ai.provider.contextWindowTokensOrNull
+import me.rerere.ai.provider.inferModelTypeFromId
 import me.rerere.ai.provider.usesVolcengineMultimodalEmbeddingApi
+import me.rerere.ai.registry.ModelRegistry
 import me.rerere.ai.ui.ImageGenerationItem
 import me.rerere.ai.ui.StreamChunk
 import me.rerere.ai.ui.UIMessage
@@ -89,7 +91,10 @@ class OpenAIProvider(
                 Model(
                     modelId = id,
                     displayName = id,
-                    type = inferModelType(id),
+                    type = inferOpenAIModelType(id),
+                    inputModalities = ModelRegistry.MODEL_INPUT_MODALITIES.getData(id),
+                    outputModalities = ModelRegistry.MODEL_OUTPUT_MODALITIES.getData(id),
+                    abilities = ModelRegistry.MODEL_ABILITIES.getData(id),
                     contextWindowTokens = modelObj.contextWindowTokensOrNull(
                         modelId = id,
                         protocol = ModelDiscoveryProtocol.OPENAI,
@@ -416,28 +421,9 @@ class OpenAIProvider(
         else -> "image/png"
     }
 
-    private fun inferModelType(modelId: String): ModelType {
-        val normalized = modelId.lowercase()
-        return if (
-            normalized.contains("embedding") ||
-            normalized.contains("embed") ||
-            normalized.contains("embed-") ||
-            normalized.startsWith("bge") ||
-            normalized.contains("/bge") ||
-            normalized.contains("e5") ||
-            normalized.contains("mxbai") ||
-            normalized.contains("nomic") ||
-            normalized.startsWith("e5-") ||
-            normalized.contains("gte") ||
-            normalized.contains("jina-embeddings")
-        ) {
-            ModelType.EMBEDDING
-        } else {
-            ModelType.CHAT
-        }
-    }
-
     companion object {
         private val SUPPORTED_EDIT_IMAGE_EXTENSIONS = setOf("png", "jpg", "jpeg", "webp")
     }
 }
+
+internal fun inferOpenAIModelType(modelId: String): ModelType = inferModelTypeFromId(modelId)

--- a/ai/src/main/java/me/rerere/ai/registry/ModelRegistry.kt
+++ b/ai/src/main/java/me/rerere/ai/registry/ModelRegistry.kt
@@ -2,6 +2,8 @@ package me.rerere.ai.registry
 
 import me.rerere.ai.provider.Modality
 import me.rerere.ai.provider.ModelAbility
+import me.rerere.ai.provider.ModelType
+import me.rerere.ai.provider.inferModelTypeFromId
 
 fun interface ModelData<T> {
     fun getData(modelId: String): T
@@ -631,12 +633,19 @@ object ModelRegistry {
         QWEN_MT
     )
 
+    val MODEL_TYPE = ModelData(::inferModelTypeFromId)
+
     val MODEL_INPUT_MODALITIES = ModelData { modelId ->
-        resolveModalities(modelId) { it.inputModalities }
+        resolveModalities(modelId, fallback = listOf(Modality.TEXT)) { it.inputModalities }
     }
 
     val MODEL_OUTPUT_MODALITIES = ModelData { modelId ->
-        resolveModalities(modelId) { it.outputModalities }
+        val fallback = if (MODEL_TYPE.getData(modelId) == ModelType.IMAGE) {
+            listOf(Modality.IMAGE)
+        } else {
+            listOf(Modality.TEXT)
+        }
+        resolveModalities(modelId, fallback = fallback) { it.outputModalities }
     }
 
     val MODEL_ABILITIES = ModelData { modelId ->
@@ -669,13 +678,14 @@ object ModelRegistry {
 
     private fun resolveModalities(
         modelId: String,
+        fallback: List<Modality>,
         selector: (ModelDefinition) -> Set<Modality>
     ): List<Modality> {
         val modalities = resolveModels(modelId)
             .flatMap { selector(it) }
             .toSet()
         return if (modalities.isEmpty()) {
-            listOf(Modality.TEXT)
+            fallback
         } else {
             listOf(Modality.TEXT, Modality.IMAGE).filter { it in modalities }
         }

--- a/ai/src/test/java/me/rerere/ai/provider/ModelContextWindowTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/ModelContextWindowTest.kt
@@ -26,6 +26,8 @@ class ModelContextWindowTest {
             "{\"limits\":{\"max_input_tokens\":200000}}" to 200_000,
             "{\"architecture\":{\"max_context_length\":65536}}" to 65_536,
             "{\"top_provider\":{\"context_length\":131072}}" to 131_072,
+            "{\"Model_Info\":{\"MAX_MODEL_LEN\":262144}}" to 262_144,
+            "{\"metadata\":{\"maxPositionEmbeddings\":32768}}" to 32_768,
         )
 
         values.forEach { (body, expected) ->
@@ -59,12 +61,28 @@ class ModelContextWindowTest {
             empty.contextWindowTokensOrNull("gpt-5", ModelDiscoveryProtocol.OPENAI),
         )
         assertEquals(
+            1_050_000,
+            empty.contextWindowTokensOrNull("gpt-5.6", ModelDiscoveryProtocol.OPENAI),
+        )
+        assertEquals(
+            400_000,
+            empty.contextWindowTokensOrNull("gpt-5.4-mini", ModelDiscoveryProtocol.OPENAI),
+        )
+        assertEquals(
             1_048_576,
             empty.contextWindowTokensOrNull("gemini-2.5-flash", ModelDiscoveryProtocol.GOOGLE),
         )
         assertEquals(
             200_000,
             empty.contextWindowTokensOrNull("claude-sonnet-4-5", ModelDiscoveryProtocol.ANTHROPIC),
+        )
+        assertEquals(
+            1_000_000,
+            empty.contextWindowTokensOrNull("claude-opus-4-6", ModelDiscoveryProtocol.ANTHROPIC),
+        )
+        assertEquals(
+            131_072,
+            empty.contextWindowTokensOrNull("gemini-3.1-flash-image-preview", ModelDiscoveryProtocol.GOOGLE),
         )
         assertEquals(
             64_000,
@@ -88,7 +106,7 @@ class ModelContextWindowTest {
             Model(modelId = "custom-deployment"),
         )
         val discovered = listOf(
-            Model(modelId = "gpt-5", contextWindowTokens = 400_000),
+            Model(modelId = "OPENAI/GPT-5", contextWindowTokens = 400_000),
             Model(modelId = "gpt-4o", contextWindowTokens = 128_000),
         )
 

--- a/ai/src/test/java/me/rerere/ai/provider/providers/ProviderModelDiscoveryTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/ProviderModelDiscoveryTest.kt
@@ -2,6 +2,7 @@ package me.rerere.ai.provider.providers
 
 import kotlinx.coroutines.runBlocking
 import me.rerere.ai.provider.ProviderSetting
+import me.rerere.ai.provider.ModelType
 import me.rerere.ai.provider.providers.claude.ClaudeProvider
 import me.rerere.ai.provider.providers.google.GoogleProvider
 import me.rerere.ai.provider.providers.openai.OpenAIProvider
@@ -22,7 +23,12 @@ class ProviderModelDiscoveryTest {
                 """
                 {"data":[
                   {"id":"gpt-5"},
-                  {"id":"gpt-4o","context_length":64000}
+                  {"id":"gpt-4o","context_length":64000},
+                  {"id":"doubao-seedream-4-0"},
+                  {"id":"gpt-image-2"},
+                  {"id":"grok-imagine-image-2.0"},
+                  {"id":"grok-imagine-image-quality"},
+                  {"id":"grok-imagine-image-pro"}
                 ]}
                 """.trimIndent()
             )
@@ -34,6 +40,11 @@ class ProviderModelDiscoveryTest {
 
         assertEquals(400_000, models[0].contextWindowTokens)
         assertEquals(64_000, models[1].contextWindowTokens)
+        assertEquals(ModelType.IMAGE, models[2].type)
+        assertEquals(ModelType.IMAGE, models[3].type)
+        assertEquals(ModelType.IMAGE, models[4].type)
+        assertEquals(ModelType.IMAGE, models[5].type)
+        assertEquals(ModelType.IMAGE, models[6].type)
     }
 
     @Test
@@ -52,6 +63,21 @@ class ProviderModelDiscoveryTest {
                     "name":"models/gemini-2.0-flash",
                     "displayName":"Gemini 2.0 Flash",
                     "supportedGenerationMethods":["generateContent"]
+                  },
+                  {
+                    "name":"models/imagen-4.0-generate-001",
+                    "displayName":"Imagen 4",
+                    "supportedGenerationMethods":["predict"]
+                  },
+                  {
+                    "name":"models/gemini-3-pro-image-preview",
+                    "displayName":"Gemini 3 Pro Image",
+                    "supportedGenerationMethods":["generateContent"]
+                  },
+                  {
+                    "name":"models/gemini-3.1-flash-image-preview",
+                    "displayName":"Gemini 3.1 Flash Image",
+                    "supportedGenerationMethods":["generateContent"]
                   }
                 ]}
                 """.trimIndent()
@@ -62,6 +88,11 @@ class ProviderModelDiscoveryTest {
 
         assertEquals(2_000_000, models[0].contextWindowTokens)
         assertEquals(1_048_576, models[1].contextWindowTokens)
+        assertEquals(ModelType.IMAGE, models[2].type)
+        assertEquals(ModelType.IMAGE, models[3].type)
+        assertEquals(65_536, models[3].contextWindowTokens)
+        assertEquals(ModelType.IMAGE, models[4].type)
+        assertEquals(131_072, models[4].contextWindowTokens)
     }
 
     @Test

--- a/ai/src/test/java/me/rerere/ai/registry/ModelRegistryTest.kt
+++ b/ai/src/test/java/me/rerere/ai/registry/ModelRegistryTest.kt
@@ -2,6 +2,7 @@ package me.rerere.ai.registry
 
 import me.rerere.ai.provider.Modality
 import me.rerere.ai.provider.ModelAbility
+import me.rerere.ai.provider.ModelType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -37,6 +38,14 @@ class ModelRegistryTest {
             listOf(Modality.TEXT),
             ModelRegistry.MODEL_OUTPUT_MODALITIES.getData("gemini-2.5-flash")
         )
+    }
+
+    @Test
+    fun testImageModelTypes() {
+        assertEquals(ModelType.IMAGE, ModelRegistry.MODEL_TYPE.getData("gemini-3-pro-image-preview"))
+        assertEquals(ModelType.IMAGE, ModelRegistry.MODEL_TYPE.getData("gemini-3.1-flash-image-preview"))
+        assertEquals(ModelType.IMAGE, ModelRegistry.MODEL_TYPE.getData("gpt-image-2"))
+        assertEquals(ModelType.EMBEDDING, ModelRegistry.MODEL_TYPE.getData("BAAI/bge-m3"))
     }
 
     @Test


### PR DESCRIPTION
## Changes / 更新内容

- Add shared model-type inference for chat, embedding, and image models used by official and compatible APIs.
- 新增统一的模型类型推断，覆盖官方及兼容接口中的聊天、嵌入和图片模型。
- Populate model type, input/output modalities, and abilities during OpenAI, Google, and Anthropic model discovery.
- 在 OpenAI、Google 和 Anthropic 模型发现时补充模型类型、输入输出模态和能力信息。
- Recognize additional context-window metadata fields, normalize model identifiers, and improve known-capacity fallbacks.
- 扩展上下文窗口元数据字段识别，规范化模型标识，并改进已知模型容量回退。
- Increase Google and Anthropic model discovery page sizes so larger provider catalogs are not truncated.
- 提高 Google 与 Anthropic 模型发现分页数量，避免较大的供应商模型清单被截断。

## Validation / 验证

- Passed focused AI module tests for context-window parsing, model registry inference, and OpenAI/Google/Anthropic model discovery.
- 已通过上下文窗口解析、模型注册表推断及 OpenAI/Google/Anthropic 模型发现相关 AI 模块测试。
