### PR TITLE
[codex] sync formal release docs 2.4.8-revised.4 / 同步正式版文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Later upstream releases are not automatically included.
 | --- | --- |
 | Distribution name | `Rikkahub Revised` |
 | Android application ID | `me.rerere.rikkahub.revised` |
-| Current release | [`v2.4.8-revised.3`](https://github.com/YaeNovin/Rikkahub-Revised/releases/tag/v2.4.8-revised.3) |
+| Current release | [`v2.4.8-revised.4`](https://github.com/YaeNovin/Rikkahub-Revised/releases/tag/v2.4.8-revised.4) |
 | Minimum Android version | Android 8.0 (API 26) |
 | Source repository | `YaeNovin/Rikkahub-Revised` |
 | License | GNU Affero General Public License v3.0 |
@@ -64,6 +64,24 @@ repository.
 
 Rikkahub Revised keeps the upstream Android client as its foundation and adds
 or changes the following areas:
+
+### Current Formal Release: v2.4.8-revised.4
+
+- Improved model capability, context-window, and reasoning-parameter detection
+  for Qwen, DeepSeek, Doubao, and compatible providers.
+- Standardized GPT Image 2 size, aspect-ratio, and quality parameters, with
+  improved Gemini, Grok, and Seedream image-generation compatibility.
+- Upgraded the image gallery with previews, details, folders, image import,
+  metadata backup, and batch add, move, and delete operations.
+- Improved automatic reconnection for network changes, rate limits, interrupted
+  connections, chat continuation, and image generation or editing.
+- Improved full-conversation and file token accounting, context-window
+  detection, and automatic context compression reliability.
+- Fixed DOC, DOCX, and XLSX parsing and improved large multimedia attachments
+  and complex MIDI processing.
+- Localized software error messages and added a seven-day, entry-based
+  diagnostic log viewer.
+- Improved MCP OAuth authorization, connection status, and reconnect feedback.
 
 - Token-aware rolling context summaries, automatic context-window discovery,
   animated compression feedback, and context usage display.

--- a/README_ZH_CN.md
+++ b/README_ZH_CN.md
@@ -27,7 +27,7 @@
 | --- | --- |
 | 发行名称 | `Rikkahub Revised` |
 | Android 应用 ID | `me.rerere.rikkahub.revised` |
-| 当前版本 | [`v2.4.8-revised.3`](https://github.com/YaeNovin/Rikkahub-Revised/releases/tag/v2.4.8-revised.3) |
+| 当前版本 | [`v2.4.8-revised.4`](https://github.com/YaeNovin/Rikkahub-Revised/releases/tag/v2.4.8-revised.4) |
 | 最低 Android 版本 | Android 8.0（API 26） |
 | 源码仓库 | `YaeNovin/Rikkahub-Revised` |
 | 开源协议 | GNU Affero General Public License v3.0 |
@@ -58,6 +58,18 @@ APK。Release 说明仅包含面向用户的更新与修复；安装包完整性
 ## Revised 的主要改动
 
 Rikkahub Revised 以上游 Android 客户端为基础，主要增加或调整了以下内容：
+
+### 当前正式版：v2.4.8-revised.4
+
+- 优化千问、DeepSeek、豆包及兼容供应商的模型能力、上下文窗口与推理参数识别。
+- 规范 GPT Image 2 的图片尺寸、比例和质量参数，并完善 Gemini、Grok 与
+  Seedream 生图兼容性。
+- 升级图库预览、详情、文件夹、图片导入、元数据备份，以及批量添加、移动和删除。
+- 改进网络切换、限流、连接中断、聊天续答，以及生图和图片编辑过程中的自动重连。
+- 提升完整对话和文件的 Token 统计、上下文窗口识别与自动压缩可靠性。
+- 修复 DOC、DOCX、XLSX 解析，并优化大型多媒体附件和复杂 MIDI 文件处理。
+- 汉化软件错误提示，增加按条目保存七天的诊断日志及查看入口。
+- 完善 MCP OAuth 授权、连接状态和重连反馈。
 
 - 基于 Token 的滚动上下文摘要、上下文窗口自动识别、压缩动画提示和使用量展示。
 - 本地知识库、文档导入与分块、混合检索、助手绑定、RAG、来源引用和文件预览。

--- a/docs/MODIFICATIONS.md
+++ b/docs/MODIFICATIONS.md
@@ -1,16 +1,44 @@
 # Rikkahub Revised Modification Notice
 
-Notice date: 2026-08-18
+Notice date: 2026-08-21
 
 This repository is a modified distribution of the upstream
 [RikkaHub project](https://github.com/rikkahub/rikkahub). It is based on the
 upstream `2.4.8` tag at commit
 `8824e0e841f2008b322ca8214a27a978e4b4abaa`. The first revised release line is
-`2.4.8-revised.1`; the current published release is `2.4.8-revised.3`.
+`2.4.8-revised.1`; the current published release is `2.4.8-revised.4`.
 
 This file describes the modified work as required for an auditable AGPL-3.0
 release. It does not claim authorship of unchanged upstream code. Release checks
 are maintained separately from user-facing release descriptions.
+
+## 2.4.8-revised.4 Maintenance Changes / 维护变更
+
+- English: Improved model capability, context-window, and reasoning-parameter
+  detection for Qwen, DeepSeek, Doubao, and compatible providers.
+  中文：优化千问、DeepSeek、豆包及兼容供应商的模型能力、上下文窗口与推理参数识别。
+- English: Standardized GPT Image 2 size, aspect-ratio, and quality parameters,
+  and improved Gemini, Grok, and Seedream image-generation compatibility.
+  中文：规范 GPT Image 2 的图片尺寸、比例和质量参数，并完善 Gemini、Grok 与
+  Seedream 生图兼容性。
+- English: Upgraded the image gallery with previews, details, folders, image
+  import, metadata backup, and batch add, move, and delete operations.
+  中文：升级图库预览、详情、文件夹、图片导入、元数据备份，以及批量添加、移动和删除。
+- English: Improved automatic reconnection for network changes, rate limits,
+  interrupted connections, chat continuation, and image generation or editing.
+  中文：改进网络切换、限流、连接中断、聊天续答，以及生图和图片编辑过程中的自动重连。
+- English: Improved full-conversation and file token accounting, context-window
+  detection, and automatic context compression reliability.
+  中文：提升完整对话和文件的 Token 统计、上下文窗口识别与自动压缩可靠性。
+- English: Fixed DOC, DOCX, and XLSX parsing and improved large multimedia
+  attachments and complex MIDI processing.
+  中文：修复 DOC、DOCX、XLSX 解析，并优化大型多媒体附件和复杂 MIDI 文件处理。
+- English: Localized software error messages and added a seven-day,
+  entry-based diagnostic log viewer.
+  中文：汉化软件错误提示，增加按条目保存七天的诊断日志及查看入口。
+- English: Improved MCP OAuth authorization, connection status, and reconnect
+  feedback.
+  中文：完善 MCP OAuth 授权、连接状态和重连反馈。
 
 ## 2.4.8-revised.3 Maintenance Changes / 维护变更
 
@@ -108,7 +136,7 @@ scripts, license, this modification notice, and applicable third-party notices.
 
 ## Build and Signing Notes
 
-- `release` uses `2.4.8-revised.3` and signing values
+- `release` uses `2.4.8-revised.4` and signing values
   from ignored `local.properties` when supplied.
 - The release application ID is `me.rerere.rikkahub.revised`; Debug and QA add
   `.debug` and `.qa` respectively so test builds do not replace a signed release.

--- a/docs/RELEASE_SIGNING.md
+++ b/docs/RELEASE_SIGNING.md
@@ -68,7 +68,7 @@ Before publishing an APK or AAB:
 - Repository: `https://github.com/YaeNovin/Rikkahub-Revised`
 - API: `https://api.github.com/repos/YaeNovin/Rikkahub-Revised/releases/latest`
 - First tag/version: `v2.4.8-revised.1` / `2.4.8-revised.1`
-- Current tag/version: `v2.4.8-revised.3` / `2.4.8-revised.3`
+- Current tag/version: `v2.4.8-revised.4` / `2.4.8-revised.4`
 - APK assets: `app-arm64-v8a-release.apk`, `app-x86_64-release.apk`, and
   `app-universal-release.apk`
 


### PR DESCRIPTION
What changed / 变更：同步英文与简体中文 README、修改记录和签名发布契约至正式版 v2.4.8-revised.4，并补充正式版面向用户的功能亮点。
 
Why / 原因：让公开文档与昨日已发布的正式版保持一致，避免将测试包或实验性开发内容写入公开说明。
 
Validation / 校验：通过 git diff --check；提交仅包含 README.md、README_ZH_CN.md、docs/MODIFICATIONS.md 和 docs/RELEASE_SIGNING.md。
 
Scope / 范围：文档专用变更，未包含当前工作树中的源代码修改。